### PR TITLE
Timer customizavel

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ app.controller('MainController', ['$scope', '$http', function($scope, $http){
     getPerguntas().then(function(response){
       $scope.perguntas = response.data.perguntas;
       $scope.contador = Math.floor(Math.random() * ($scope.perguntas.length - 0)) + 0;
+      timeout = $scope.perguntas[$scope.contador].time ? $scope.perguntas[$scope.contador] : timeout;
       mostraPergunta();
     });
   };
@@ -50,7 +51,11 @@ app.controller('MainController', ['$scope', '$http', function($scope, $http){
   };
 
   var startTimer = function() {
-    $scope.time = timeout;
+    if (! $scope.perguntas[$scope.contador].tempo) {
+      $scope.time = timeout;
+    } else {
+      $scope.time = $scope.perguntas[$scope.contador].tempo;
+    }
     timer = setInterval(function() {
       $scope.time--;
       if($scope.time == 0){

--- a/data.json
+++ b/data.json
@@ -1,6 +1,46 @@
 {
   "perguntas": [
     {
+      "pergunta": "Qual é o valor da variável $a, dado que $a = stristr('ElePHPant', 'p', true)",
+      "alternativas": ["PHP", "Ele", "ElePHPant", "php", "PHPAnt"],
+      "correta": 1
+    },
+    {
+      "pergunta": "Em qual versão o PHP ganhou uma API de hashing de senhas?",
+      "alternativas": [5.3, 5.4, 5.5, 5.6, 7],
+      "correta": 2
+    },
+    {
+      "pergunta": "Quais são, respectivamente, os métodos mágicos chamados antes de serialize()?",
+      "alternativas": [
+        "__serialize() e __unserialize()",
+        "__sleep() e __wakeup()",
+        "__begin() e __end()",
+        "__construct() e __destruct()"
+      ],
+      "correta": 1
+    },
+    {
+      "pergunta": "O que a keyword 'final' faz?",
+      "alternativas": [
+        "Impede que uma classe ou método seja sobrescrito",
+        "Encerra o script PHP",
+        "Indica o final do programa",
+        "Nada, pois keyword 'final' não existe"
+      ],
+      "correta": 0
+    },
+    {
+      "pergunta": "Zivinho quer que seu sistema PHP funcione com qualquer banco de dados sem depender de funções específicas (como mysql_* para MySQL). Como ele pode fazer isso?",
+      "alternativas": [
+        "Não pode",
+        "Com PDO",
+        "Com ADODB",
+        "Com PHP Global Databases"
+      ],
+      "correta": 1
+    },
+    {
       "pergunta": "Qual das funcões pode ser usada para verificar se um número é inteiro?",
       "alternativas": ["int", "is_interger", "is_int", "isInt", "isInteger"],
       "correta": 2


### PR DESCRIPTION
Fiz uma pequena mudança para permitir a customização do tempo de resposta para cada pergunta, assim, perguntas mais longas podem ter tempos de timeout maiores, assim como perguntas mais simples podem ter tempos menores.

Exemplo com o tempo customizado:

```
{
  "pergunta": Pergunta",
  "alternativas": [
    "Respota 1", 
    "Reposta 2"não existe"
  ],
  "correta": 0,
  "tempo": 30 // 30 segundos para responder
},
```

}

Tempo padrão (15 segundos)

```
{
  "pergunta": Pergunta",
  "alternativas": [
    "Respota 1", 
    "Reposta 2"não existe"
  ],
  "correta": 0
},
```

resolves #8 
